### PR TITLE
document mps module

### DIFF
--- a/assets/js/connect.js
+++ b/assets/js/connect.js
@@ -159,6 +159,7 @@ $(document).ready(function() {
       "module load slurm \n" +
       "module load nvhpc \n" +
       "module load cudnn/cuda12/9.3.0.75 \n" +
+      "module load mps   # Optional: prevents CUDA_ERROR_MPS_CONNECTION_FAILED \n" +
       "\n" +
       "bash ~/test.sh \n"
     replaceText('sbatch', newStr);

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,20 @@ Docker is not supported on Marlowe due to the security risks associated with it.
 
 CUDA tools and libraries such as nvcc are available in the nvhpc module. This module is not loaded by default, so it will need to be loaded whenever you use any CUDA tools and libraries. You can always automate this by adding `module load nvhpc` to your `~/.bashrc` file.
 
+### My job crashes with CUDA_ERROR_MPS_CONNECTION_FAILED
+
+The `CUDA_ERROR_MPS_CONNECTION_FAILED` error can happen during any job that uses CUDA under the hood (PyTorch, JAX, etc.) if a leftover `/tmp/nvidia-mps` directory from another job is present on the node. To prevent this from happening, load the MPS helper module inside your job:
+```
+module load mps
+```
+This automatically defines job-specific `/tmp` directories by setting
+```
+CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps-$SLURM_JOB_ID
+CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-log-$SLURM_JOB_ID
+```
+
+The module can be loaded anywhere in the job before your CUDA code runs. A Slurm epilog script will automatically remove any job-specific directories automatically once the job ends.
+
 ### I can't see my project directory
 
 The `/projects/` filesystem uses a system called [autofs](https://www.kernel.org/doc/html/latest/filesystems/autofs.html) to dynamically mount NFS shares in `/projects/`.

--- a/docs/modules/cudatoolkit.md
+++ b/docs/modules/cudatoolkit.md
@@ -16,6 +16,12 @@ To load Cuda Toolkit, run the following:
 module load cudatoolkit
 ```
 
+If your job crashes with `CUDA_ERROR_MPS_CONNECTION_FAILED`, add 
+```
+module load mps
+```
+before running CUDA. See [FAQ entry](/faq.html#my-job-crashes-with-cuda_error_mps_connection_failed) for details.
+
 ### Stock Cuda Toolkit
 
 If you absolutely need a stock cuda toolkit install, you can load the following module:

--- a/docs/modules/cudnn.md
+++ b/docs/modules/cudnn.md
@@ -20,3 +20,9 @@ To load CuDNN, run the following:
 ```
 module load cudnn/cuda12
 ```
+
+If your job crashes with `CUDA_ERROR_MPS_CONNECTION_FAILED`, add 
+```
+module load mps
+```
+before running CUDA. See [FAQ entry](/faq.html#my-job-crashes-with-cuda_error_mps_connection_failed) for details.

--- a/docs/modules/nvhpc.md
+++ b/docs/modules/nvhpc.md
@@ -15,3 +15,9 @@ module load nvhpc
 ```
 
 Due to NVPC overwriting the local CC and CXX variables, by default it is not loaded. This means you will have to load the nvhpc module whenever you want to use any CUDA tools.
+
+If your job crashes with `CUDA_ERROR_MPS_CONNECTION_FAILED`, add 
+```
+module load mps
+```
+before running CUDA. See [FAQ entry](/faq.html#my-job-crashes-with-cuda_error_mps_connection_failed) for details.

--- a/docs/modules/software.md
+++ b/docs/modules/software.md
@@ -7,8 +7,10 @@ toc: false
 
 Marlowe has multiple software packages pre-installed and available for use. 
 
-Most are installed as modules and can be listed by running `module avail` in your terminal
+Most are installed as modules and can be listed by running `module avail` in your terminal.
 
-The only modules loaded by default are `slurm` and `gcc/13.1.0`. If you need other module automatically loaded, it is recommended to add `module load <modulename>` to your `~/.bashrc` file.
+The only modules loaded by default are `slurm` and `gcc/13.1.0`. If you need other modules automatically loaded, it is recommended to add `module load <modulename>` to your `~/.bashrc` file.
 
-Choose a page on the left to learn more about them.
+If your jobs are crashing with `CUDA_ERROR_MPS_CONNECTION_FAILED` use `module load mps`. See the [FAQ entry](/faq.html#my-job-crashes-with-cuda_error_mps_connection_failed) for details.
+
+Choose a page on the left to learn more about software on Marlowe.

--- a/docs/slurm_and_openOnDemand/slurm.md
+++ b/docs/slurm_and_openOnDemand/slurm.md
@@ -91,6 +91,7 @@ _optional: enter your information below and click the Generate button to generat
 module load slurm
 module load nvhpc
 module load cudnn/cuda12/9.3.0.75
+module load mps   # Optional: prevents CUDA_ERROR_MPS_CONNECTION_FAILED
 
 bash ~/test.sh
 ```
@@ -101,6 +102,8 @@ bash ~/test.sh
 </div>
 </div>
 </div>
+
+> **Tip:** If your job crashes with `CUDA_ERROR_MPS_CONNECTION_FAILED`, load `mps` as shown above before launching the job. See the [FAQ entry](/faq.html#my-job-crashes-with-cuda_error_mps_connection_failed) for details.
 
 ## Check GPU allocation usage
 


### PR DESCRIPTION
This pull request introduces documentation updates to help users resolve the `CUDA_ERROR_MPS_CONNECTION_FAILED` error when running CUDA jobs on Marlowe. The main improvement is the recommendation to load the `mps` module in job scripts and documentation, with explanations of why this is necessary and how it works. These changes are reflected across multiple documentation files and example scripts.

**Documentation updates for CUDA job troubleshooting:**

* Added a new FAQ entry explaining the cause of `CUDA_ERROR_MPS_CONNECTION_FAILED` and how loading the `mps` module resolves it by creating job-specific `/tmp` directories and cleaning them up automatically.
* Updated module documentation pages (`cudatoolkit.md`, `cudnn.md`, `nvhpc.md`, `software.md`) to recommend loading the `mps` module if jobs crash with this error, and linked to the new FAQ entry for more details. [[1]](diffhunk://#diff-17c63d2c188cf3e0e21cd749ead3cbc222a38f1c1a64b4e34399427fab8517b5R19-R24) [[2]](diffhunk://#diff-5d8233b9d0a18383ce418d12a4ccf1693e89f4679d5573b12575853df563fa82R23-R28) [[3]](diffhunk://#diff-8fe04ea740e774f7dab368917c480a3b5d9e5f65f0478957276bd0d9be86dbc5R18-R23) [[4]](diffhunk://#diff-5d09abefc7263e936fb32ce18a2a6af057a137503998dd231621441cc334038bL10-R16)

**Job script and example updates:**

* Modified example Slurm job scripts and code snippets to include `module load mps` as an optional step to prevent the CUDA error. [[1]](diffhunk://#diff-d982e51b3949f087ce670ffce3be5d6a634e940cee7d42117d18bf1cb39cff01R162) [[2]](diffhunk://#diff-642d96041cc65c737bec3748925521881fcafb16f94f4dd1db956d2bb8f4f565R94)
* Added a tip to the Slurm documentation page, reminding users to load the `mps` module if they encounter the error, with a link to the FAQ for further guidance.